### PR TITLE
[BREW-13] Basic Brewing Method CRUD

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,10 @@
 {
   "cSpell.words": [
+    "aeropress",
+    "Breville",
+    "chemex",
     "lograge",
+    "pourover",
     "Shoulda"
   ]
 }

--- a/app/controllers/brewing_methods_controller.rb
+++ b/app/controllers/brewing_methods_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class BrewingMethodsController < ApplicationController
+  def index
+    # @brewing_methods = current_user.brewing_methods
+    @brewing_methods = BrewingMethod.all
+  end
+
+  def new
+    # @brewing_method = current_user.brewing_methods.build
+    @brewing_method = BrewingMethod.new
+
+    render layout: 'modal'
+  end
+
+  def edit
+    # @brewing_method = current_user.brewing_methods.find(params[:id])
+    @brewing_method = BrewingMethod.find(params[:id])
+
+    render layout: 'modal'
+  end
+
+  def create
+    # @brewing_method = current_user.brewing_methods.new(brewing_method_params)
+    @brewing_method = BrewingMethod.new(brewing_method_params)
+
+    if @brewing_method.save
+      redirect_to brewing_methods_path, notice: 'Brewing Method was successfully created.'
+    else
+      render :new, layout: 'modal', status: :unprocessable_entity
+    end
+  end
+
+  def update
+    # @brewing_method = current_user.brewing_methods.find(params[:id])
+    @brewing_method = BrewingMethod.find(params[:id])
+
+    if @brewing_method.update(brewing_method_params)
+      redirect_to brewing_methods_path, notice: 'Brewing Method was successfully updated.'
+    else
+      render :edit, layout: 'modal', status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @brewing_method = BrewingMethod.find(params[:id])
+    @brewing_method.destroy
+
+    redirect_to brewing_methods_path, notice: 'Brewing Method was successfully deleted.'
+  end
+
+  private
+
+  def brewing_method_params
+    params.expect(brewing_method: %i[name prep_type])
+  end
+end

--- a/app/helpers/brewing_methods_helper.rb
+++ b/app/helpers/brewing_methods_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BrewingMethodsHelper
+  def brewing_method_prep_type_options
+    BrewingMethod.prep_types.keys.map do |type|
+      [type.humanize, type]
+    end
+  end
+end

--- a/app/inputs/collection_select_input.rb
+++ b/app/inputs/collection_select_input.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
-  def input_html_classes
-    super.push('form__dropdown')
-  end
-end

--- a/app/inputs/grouped_collection_select_input.rb
+++ b/app/inputs/grouped_collection_select_input.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class GroupedCollectionSelectInput < SimpleForm::Inputs::GroupedCollectionSelectInput
-  def input_html_classes
-    super.push('form__dropdown')
-  end
-end

--- a/app/models/brewing_method.rb
+++ b/app/models/brewing_method.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class BrewingMethod < ApplicationRecord
+  enum :prep_type, {
+    espresso: 'espresso',
+    aeropress: 'aeropress',
+    drip: 'drip',
+    chemex: 'chemex',
+    pourover: 'pourover',
+    other: 'other'
+  }, validate: true
+
+  validates :name, presence: true
+end

--- a/app/views/beans/index.html.slim
+++ b/app/views/beans/index.html.slim
@@ -3,5 +3,4 @@ section.page-section
     h1 Beans
     = modal_link_to 'New Bean', new_bean_path, class: 'btn btn--primary'
 
-section.page-section
   = render @beans

--- a/app/views/brewing_methods/_brewing_method.html.slim
+++ b/app/views/brewing_methods/_brewing_method.html.slim
@@ -1,0 +1,18 @@
+-# locals: (brewing_method:)
+
+.card data-testid=dom_id(brewing_method)
+  .card__header
+    .flex.justify-between
+      span = brewing_method.name
+      .flex.gap-md
+        = modal_link_to edit_brewing_method_path(brewing_method), class: 'btn btn--icon btn--no-border btn--small', data: { 'tooltip-text': 'Edit', 'tooltip-position': 'left' } do
+          = icon('pencil-simple')
+          .sr-only Edit
+        = button_to brewing_method_path(brewing_method), method: :delete, class: 'btn btn--icon btn--destructive btn--small', data: { 'tooltip-text': 'Delete', 'tooltip-position': 'left', turbo_confirm: 'Are you sure?' } do
+          = icon('trash')
+          .sr-only Delete
+  .card__body
+    .flex.gap-xl
+      .text-pair
+        span.text-pair__title Prep Type
+        span.text-pair__subtitle = brewing_method.prep_type.humanize

--- a/app/views/brewing_methods/_form.html.slim
+++ b/app/views/brewing_methods/_form.html.slim
@@ -1,0 +1,6 @@
+= simple_form_for @brewing_method do |f|
+  = f.input :name, placeholder: 'e.g. French Press'
+  = f.input :prep_type, collection: brewing_method_prep_type_options, prompt: 'Select a Prep Type'
+
+  - content_for :modal_actions do
+    = f.submit class: 'btn btn--primary', form: f.id

--- a/app/views/brewing_methods/edit.html.slim
+++ b/app/views/brewing_methods/edit.html.slim
@@ -1,0 +1,4 @@
+- content_for :modal_title do
+  span Edit Brewing Method
+
+= render 'form'

--- a/app/views/brewing_methods/index.html.slim
+++ b/app/views/brewing_methods/index.html.slim
@@ -1,0 +1,6 @@
+section.page-section
+  .flex.justify-between.items-center
+    h1 Brewing Methods
+    = modal_link_to 'New Brewing Method', new_brewing_method_path, class: 'btn btn--primary'
+
+  = render @brewing_methods

--- a/app/views/brewing_methods/new.html.slim
+++ b/app/views/brewing_methods/new.html.slim
@@ -1,0 +1,4 @@
+- content_for :modal_title do
+  span New Brewing Method
+
+= render 'form'

--- a/app/views/layouts/modal.html.slim
+++ b/app/views/layouts/modal.html.slim
@@ -16,7 +16,7 @@ html lang='en'
         .modal data-testid="modal-content"
           .modal__header
             = yield :modal_title
-            = button_tag( icon('close', size: 'x-large'), class: 'btn btn--no-border btn--icon btn--pill', data: { action: "toggle#off" })
+            = button_tag( icon('x', size: 'x-large'), class: 'btn btn--no-border btn--icon btn--pill', data: { action: "toggle#off" })
 
           .modal__body
             = yield

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -9,3 +9,6 @@
     = active_link_to beans_path, class: 'btn btn--no-border', class_active: 'btn--active' do
       = icon('coffee-bean')
       | Beans
+    = active_link_to brewing_methods_path, class: 'btn btn--no-border', class_active: 'btn--active' do
+      = icon('flask')
+      | Brewing Methods

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   end
 
   resources :beans
+  resources :brewing_methods
 
   # Defines the root path route ("/")
   root "pages#home"

--- a/db/migrate/20250312233612_create_brewing_methods.rb
+++ b/db/migrate/20250312233612_create_brewing_methods.rb
@@ -1,0 +1,10 @@
+class CreateBrewingMethods < ActiveRecord::Migration[8.0]
+  def change
+    create_table :brewing_methods do |t|
+      t.string :name, null: false
+      t.string :prep_type, null: false, default: 'pourover'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_12_003156) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_12_233612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_12_003156) do
     t.string "taste_profile"
     t.boolean "decaf"
     t.string "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "brewing_methods", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "prep_type", default: "pourover", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/brewing_methods.rb
+++ b/spec/factories/brewing_methods.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :brewing_method do
+    name { 'Breville Bambino Plus' }
+    prep_type { BrewingMethod.prep_types[:pourover] }
+  end
+end

--- a/spec/models/brewing_method_spec.rb
+++ b/spec/models/brewing_method_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe BrewingMethod, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it do
+      should define_enum_for(:prep_type).with_values(
+        espresso: 'espresso',
+        aeropress: 'aeropress',
+        drip: 'drip',
+        chemex: 'chemex',
+        pourover: 'pourover',
+        other: 'other'
+      ).backed_by_column_of_type(:string)
+    end
+  end
+end

--- a/spec/models/brewing_method_spec.rb
+++ b/spec/models/brewing_method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BrewingMethod, type: :model do

--- a/spec/system/brewing_methods_spec.rb
+++ b/spec/system/brewing_methods_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Brewing Methods', type: :system do
+  it 'lists brewing methods' do
+    brewing_methods = create_list(:brewing_method, 3)
+    visit brewing_methods_path
+
+    brewing_methods.each do |brewing_method|
+      expect(page).to have_content(brewing_method.name)
+    end
+  end
+
+  it 'allows a user to create a brewing_method' do
+    visit brewing_methods_path
+    click_on 'New Brewing Method'
+
+    fill_in 'Name', with: 'Breville Bambino Plus'
+    select BrewingMethod.prep_types[:espresso].humanize, from: 'Prep type'
+
+    click_on 'Create Brewing method'
+
+    expect(page).to have_content('Brewing Method was successfully created.')
+    expect(BrewingMethod.first).to have_attributes(
+      name: 'Breville Bambino Plus',
+      prep_type: BrewingMethod.prep_types[:espresso]
+    )
+  end
+
+  it 'allows a user to edit a brewing method' do
+    brewing_method = create(:brewing_method)
+    visit brewing_methods_path
+
+    within data_test(dom_id(brewing_method)) do
+      click_on 'Edit'
+    end
+
+    fill_in 'Name', with: 'Edited Method'
+
+    click_on 'Update Brewing method'
+
+    expect(page).to have_content('Brewing Method was successfully updated.')
+    expect(brewing_method.reload.name).to eq 'Edited Method'
+  end
+
+  it 'allows a user to delete a brewing method' do
+    brewing_method = create(:brewing_method)
+    visit brewing_methods_path
+
+    within data_test(dom_id(brewing_method)) do
+      click_on 'Delete'
+    end
+
+    click_on 'Yes, I\'m Sure'
+
+    expect(page).to have_content('Brewing Method was successfully deleted.')
+    expect(BrewingMethod.count).to eq 0
+  end
+end


### PR DESCRIPTION
# Why?

I want to be able to set up some methods that will be selectable when making brews

## What Changed

* [X] Add spacing to beans page
* [X] Fix modal close icon
* [X] Add model for brewing method
* [X] Add CRUD for brewing method

## Pre-merge checklist

* ~~[ ] Update relevant READMEs~~

## Screenshots

<img width="878" alt="Screenshot 2025-03-12 at 8 43 47 PM" src="https://github.com/user-attachments/assets/97a58102-4306-4df3-a83e-0e88fbdf9256" />
<img width="1728" alt="Screenshot 2025-03-12 at 8 44 05 PM" src="https://github.com/user-attachments/assets/60a48a74-977d-475d-919c-552b395f5241" />
<img width="853" alt="Screenshot 2025-03-12 at 8 44 09 PM" src="https://github.com/user-attachments/assets/d23ac501-a55b-4151-9d93-414992bb5a84" />
