### PR TITLE
Remove option

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,6 @@
 
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # Disabled for now so I can do proper lighthouse testing
+  # allow_browser versions: :modern
 end


### PR DESCRIPTION
# Why?

There is a bug in Chrome that reports the browser as older than it is when using dev tools device emulation. This breaks tools like lighthouse that change the device type during testing and make it unable to do a full test

## What Changed

* [X] Remove Option
